### PR TITLE
Add Year View Initial Styles

### DIFF
--- a/ChessHeatmap/ChessHeatmapApp.swift
+++ b/ChessHeatmap/ChessHeatmapApp.swift
@@ -13,6 +13,7 @@ struct ChessHeatmapApp: App {
         WindowGroup {
             YearResultView()
                 .with(chessClient: .live)
+                .environment(\.font, Font.custom("KaiseiDecol-Regular", size: 15))
         }
     }
 }

--- a/ChessHeatmap/Info.plist
+++ b/ChessHeatmap/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>KaiseiDecol-Regular.ttf</string>
+	</array>
+</dict>
+</plist>

--- a/ChessHeatmap/components/HeatmapView.swift
+++ b/ChessHeatmap/components/HeatmapView.swift
@@ -33,20 +33,6 @@ struct HeatmapView: View {
                     }
             }
         }
-//        List {
-//            ForEach(orderedGames.keys, id: \.self) { key in
-//                Section(key.description) {
-//                    if let games = orderedGames[key] {
-//                        ForEach(games) { game in
-//                            Text("\(game.white.username) vs \(game.black.username)")
-//                        }
-//                    }
-//                }.background {
-//                    Color.green
-//                        .opacity()
-//                }
-//            }
-//        }
     }
 }
 

--- a/ChessHeatmap/domain/OrderedGames.swift
+++ b/ChessHeatmap/domain/OrderedGames.swift
@@ -37,11 +37,26 @@ struct OrderedGames: Equatable {
     init(games: [Game]) {
         self.gameList = games
         self.games = Dictionary(grouping: games, by: { $0.endTime.withoutTimestamp })
+        self.mostGamesInADay = self.games.values.reduce(0) { max($0, $1.count) }
         self.keys = self.games.keys.sorted()
         self.firstDate = self.keys.first ?? Date()
         self.lastDate = self.keys.last ?? Date()
-        self.dateRange = Date.dates(from: firstDate, to: lastDate)
-        self.mostGamesInADay = self.games.values.reduce(0) { max($0, $1.count) }
+        
+        // Create date range for the full year based on firstDate
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: firstDate)
+        let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1))!
+        let endDate = calendar.date(from: DateComponents(year: year, month: 12, day: 31))!
+        self.dateRange = Date.dates(from: startDate, to: endDate)
+        
+        // Merge in empty games for missing dates
+        self.keys = self.dateRange
+        for date in self.dateRange {
+            if let _ = self.games[date] {
+                continue
+            }
+            self.games[date] = []
+        }
     }
 
     subscript(date: Date) -> [Game] {

--- a/ChessHeatmap/modules/YearResult/YearResultView.swift
+++ b/ChessHeatmap/modules/YearResult/YearResultView.swift
@@ -23,25 +23,46 @@ struct YearResultView: View {
 
     var body: some View {
         VStack {
+            Text("Year View")
+                .font(.custom("KaiseiDecol-Regular", size: 32))
+                .padding(.top, 34)
+                .padding(.bottom, 20)
+            HStack (spacing: 13) {
+                Text("Profiles")
+                Text("Year View")
+                Text("Compare")
+                Text("Theme")
+                Text("About")
+            }
+            Divider()
             VStack {
-                TextField("username", text: $username)
-                    .textInputAutocapitalization(.never)
-                    .padding()
-                Picker("Year", selection: $year) {
-                    ForEach(availableYears, id: \.self) { year in
-                        Text(String(year))
-                            .tag(year)
+                VStack (alignment: .leading) {
+                    Text("Username")
+                    TextField("username", text: $username)
+                        .padding(10)
+                        .textInputAutocapitalization(.never)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.gray, lineWidth: 1)
+                        )
+                }
+                HStack {
+                    Picker("Year", selection: $year) {
+                        ForEach(availableYears, id: \.self) { year in
+                            Text(String(year))
+                                .tag(year)
+                        }
                     }
-                }
-                Button("Find") {
-                    searching = true
-                }
-
+                    Button("Search") {
+                        searching = true
+                    }.buttonStyle(.bordered)
+                    
+                }.padding(.vertical, 10)
                 if let message {
                     Text(message)
                 }
             }
-            Divider()
+            .padding()
             ScrollView {
                 if let results {
                     HeatmapView(orderedGames: results)

--- a/ChessHeatmap/modules/YearResult/YearResultView.swift
+++ b/ChessHeatmap/modules/YearResult/YearResultView.swift
@@ -47,13 +47,12 @@ struct YearResultView: View {
             guard let results else { return }
             var (wins, losses, ties) = results.gameList.reduce((0, 0, 0)) { results, game in
                 var (wins, losses, ties) = results
-//                let result = game.white.username == username ? game.white.result : game.black.result
-//                switch result.simplified {
-//                case .win: wins += 1
-//                case .tie: ties += 1
-//                case .loss: losses += 1
-//                }
-
+                let result = game.white.player.username == username ? game.white.result : game.black.result
+                switch result.simplified {
+                case .win: wins += 1
+                case .tie: ties += 1
+                case .loss: losses += 1
+                }
                 return (wins, losses, ties)
             }
 


### PR DESCRIPTION
This PR adds in a Google free font, `KaiseiDecol-Regular`, and adds styles to the Year View to match the Figma spec. Navigation will be done in a future PR, but the result looks like this 👍🏻

<img width="366" alt="image" src="https://user-images.githubusercontent.com/44373521/232180842-f4ad6e80-046c-461e-ae2c-d15be25a5dac.png">