### PR TITLE
Create compare stats view

### DIFF
--- a/ChessHeatmap.xcodeproj/project.pbxproj
+++ b/ChessHeatmap.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B6735CED29F1AAA900F4C050 /* KaiseiDecol-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B6735CEC29F1AAA900F4C050 /* KaiseiDecol-Regular.ttf */; };
+		B6E07BC729F3658B00B2F89F /* CompareStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E07BC629F3658B00B2F89F /* CompareStatsView.swift */; };
 		D55B361C29DF7FBA005AD9B4 /* ChessHeatmapApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55B361B29DF7FBA005AD9B4 /* ChessHeatmapApp.swift */; };
 		D55B362029DF7FBB005AD9B4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D55B361F29DF7FBB005AD9B4 /* Assets.xcassets */; };
 		D55B362F29DF80C6005AD9B4 /* ChessClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55B362E29DF80C6005AD9B4 /* ChessClient.swift */; };
@@ -46,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		B6735CEC29F1AAA900F4C050 /* KaiseiDecol-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "KaiseiDecol-Regular.ttf"; sourceTree = "<group>"; };
+		B6E07BC629F3658B00B2F89F /* CompareStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareStatsView.swift; sourceTree = "<group>"; };
 		D55B361829DF7FBA005AD9B4 /* ChessHeatmap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessHeatmap.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D55B361B29DF7FBA005AD9B4 /* ChessHeatmapApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessHeatmapApp.swift; sourceTree = "<group>"; };
 		D55B361F29DF7FBB005AD9B4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -93,6 +95,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		B6E07BC529F3657800B2F89F /* CompareStats */ = {
+			isa = PBXGroup;
+			children = (
+				B6E07BC629F3658B00B2F89F /* CompareStatsView.swift */,
+			);
+			path = CompareStats;
+			sourceTree = "<group>";
+		};
 		D55B360F29DF7FBA005AD9B4 = {
 			isa = PBXGroup;
 			children = (
@@ -129,6 +139,7 @@
 		D55B362A29DF8090005AD9B4 /* modules */ = {
 			isa = PBXGroup;
 			children = (
+				B6E07BC529F3657800B2F89F /* CompareStats */,
 				D573571B29DFC59C005225D6 /* UserList */,
 				D573570D29DF8C30005225D6 /* YearResult */,
 			);
@@ -368,6 +379,7 @@
 				D573571129DF9712005225D6 /* HeatmapView.swift in Sources */,
 				D573571329DF9767005225D6 /* OrderedGames.swift in Sources */,
 				D573571729DF9877005225D6 /* GameResult.swift in Sources */,
+				B6E07BC729F3658B00B2F89F /* CompareStatsView.swift in Sources */,
 				D573572D29DFCD8E005225D6 /* Schema.swift in Sources */,
 				D573573529DFD2E2005225D6 /* Database.swift in Sources */,
 				D573571F29DFC5BD005225D6 /* User.swift in Sources */,

--- a/ChessHeatmap/modules/CompareStats/CompareStatsView.swift
+++ b/ChessHeatmap/modules/CompareStats/CompareStatsView.swift
@@ -11,9 +11,17 @@ struct CompareStatsView: View {
     @Environment(\.chessClient) var chessClient
     @State var username1: String = ""
     @State var username2: String = ""
+    @State var results1: OrderedGames?
+    @State var results2: OrderedGames?
+    @State var message1: String? = nil
+    @State var message2: String? = nil
     @State var searching = false
     @State private var availableYears: [Int] = []
     @State private var year: Int = Calendar.current.component(.year, from: Date())
+    
+    var isFormValid: Bool {
+        !username1.isEmpty && !username2.isEmpty
+    }
     
     private func setupAvailableYears() {
         let currentYear = Calendar.current.component(.year, from: Date())
@@ -54,15 +62,97 @@ struct CompareStatsView: View {
                 }
                 Button("Compare") {
                     searching = true
-                }.buttonStyle(.bordered)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!isFormValid)
                 
             }
             .onAppear(perform: setupAvailableYears)
             .padding(.vertical, 10)
+            HStack {
+                VStack {
+                    if let message1 {
+                        Text(message1)
+                    }
+                    ScrollView {
+                        if let results1 {
+                            HeatmapView(orderedGames: results1)
+                        }
+                    }
+                }
+                VStack {
+                    if let message2 {
+                        Text(message2)
+                    }
+                    ScrollView {
+                        if let results2 {
+                            HeatmapView(orderedGames: results2)
+                        }
+                    }
+                }
+                
+            }
+            
         }
-        
-        
+        .task(id: searching) {
+            guard searching else { return }
+            defer { searching = false }
+
+            // Fetch games for username1
+            var results1: [Game] = []
+            for month in Month.allCases {
+                print(username1)
+                print(year)
+                print(month)
+                print("finding games in month: \(month)")
+                do {
+                    results1.append(contentsOf: try await chessClient.fetchGames(.init(user: username1, year: year, month: month)))
+                } catch { print("something went wrong", error) }
+            }
+
+            // Fetch games for username2
+            var results2: [Game] = []
+            for month in Month.allCases {
+                print(username2)
+                print(year)
+                print(month)
+                print("finding games in month: \(month)")
+                do {
+                    results2.append(contentsOf: try await chessClient.fetchGames(.init(user: username2, year: year, month: month)))
+                } catch { print("something went wrong", error) }
+            }
+
+            // Set the results and message for both usernames
+            self.results1 = OrderedGames(games: results1)
+            self.results2 = OrderedGames(games: results2)
+
+            var (wins1, losses1, ties1) = results1.reduce((0, 0, 0)) { results1, game in
+                var (wins, losses, ties) = results1
+                let result = game.white.player.username == username1 ? game.white.result : game.black.result
+                switch result.simplified {
+                case .win: wins += 1
+                case .tie: ties += 1
+                case .loss: losses += 1
+                }
+                return (wins, losses, ties)
+            }
+
+            var (wins2, losses2, ties2) = results2.reduce((0, 0, 0)) { results2, game in
+                var (wins, losses, ties) = results2
+                let result = game.white.player.username == username2 ? game.white.result : game.black.result
+                switch result.simplified {
+                case .win: wins += 1
+                case .tie: ties += 1
+                case .loss: losses += 1
+                }
+                return (wins, losses, ties)
+            }
+
+            message1 = "\(username1) has \(wins1) wins, \(losses1) losses and \(ties1) draws"
+            message2 = "\(username2) has \(wins2) wins, \(losses2) losses and \(ties2) draws"
+        }
     }
+    
 }
 
 struct CompareStatsView_Previews: PreviewProvider {

--- a/ChessHeatmap/modules/CompareStats/CompareStatsView.swift
+++ b/ChessHeatmap/modules/CompareStats/CompareStatsView.swift
@@ -1,0 +1,20 @@
+//
+//  CompareStatsView.swift
+//  ChessHeatmap
+//
+//  Created by Maxwell DeMaio on 4/21/23.
+//
+
+import SwiftUI
+
+struct CompareStatsView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct CompareStatsView_Previews: PreviewProvider {
+    static var previews: some View {
+        CompareStatsView()
+    }
+}

--- a/ChessHeatmap/modules/CompareStats/CompareStatsView.swift
+++ b/ChessHeatmap/modules/CompareStats/CompareStatsView.swift
@@ -8,8 +8,60 @@
 import SwiftUI
 
 struct CompareStatsView: View {
+    @Environment(\.chessClient) var chessClient
+    @State var username1: String = ""
+    @State var username2: String = ""
+    @State var searching = false
+    @State private var availableYears: [Int] = []
+    @State private var year: Int = Calendar.current.component(.year, from: Date())
+    
+    private func setupAvailableYears() {
+        let currentYear = Calendar.current.component(.year, from: Date())
+        availableYears = Array(2007...currentYear)
+    }
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            HStack{
+                VStack (alignment: .leading) {
+                    Text("Username1")
+                    TextField("username1", text: $username1)
+                        .padding(10)
+                        .textInputAutocapitalization(.never)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.gray, lineWidth: 1)
+                        )
+                }
+                VStack (alignment: .leading) {
+                    Text("Username2")
+                    TextField("username2", text: $username2)
+                        .padding(10)
+                        .textInputAutocapitalization(.never)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.gray, lineWidth: 1)
+                        )
+                }
+            }.padding()
+            
+            HStack {
+                Picker("Year", selection: $year) {
+                    ForEach(availableYears, id: \.self) { year in
+                        Text(String(year))
+                            .tag(year)
+                    }
+                }
+                Button("Compare") {
+                    searching = true
+                }.buttonStyle(.bordered)
+                
+            }
+            .onAppear(perform: setupAvailableYears)
+            .padding(.vertical, 10)
+        }
+        
+        
     }
 }
 


### PR DESCRIPTION
This adds a view to compare two players stats with two heatmaps! The form isn't allowed to be submitted until both input fields have non-empty strings in them. This closes #8.

This is completed by calling the chess.com API sequentially. In the future, we'll check the database first to see if we have historical data as we have in the [designNotes](https://github.com/boek/ChessHeatmap/blob/main/designNotes.md).

The visual aspect of this will be tackled in #11. Right now it's a little wonky since the size of the heatmap squares are large for this view.